### PR TITLE
feat: global configuration support

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -50,11 +50,11 @@ changelog:
 # Homebrew formulas to update on release
 brews:
   - name: sandworm
-    homepage: "https://github.com/umwelt-studio/sandworm"
+    homepage: "https://github.com/holonoms/sandworm"
     description: "Project file concatenator for Claude AI"
     license: "MIT"
     repository:
-      owner: umwelt-studio
+      owner: holonoms
       name: homebrew-tap
       token: "{{ .Env.GITHUB_TOKEN }}"
     directory: Formula

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ project context.
 The typical workflow is:
 
 1. Make changes to your project
-2. Run sandworm to update your Claude project
+2. Run `sandworm` to update your Claude project
 3. Ask Claude to iterate on the new code (e.g. build new feature, refactor code)
-4. Apply Claude's suggested changes & run sandworm again
+4. Apply Claude's suggested changes & run `sandworm` again
 
 Rinse and repeat. Used in this fashion, sandworm allows you to very quickly add
 new features to your software projects by leveraging Claude (or a similar LLM).
@@ -50,32 +50,33 @@ subsequent runs of sandworm will take care of syncing the newly generated file
 with the Project's file. Every new Project Chat with Claude will include your
 whole project as context.
 
-## Advanced usage
+## Advanced topics
+
+### Usage
 
 ```
-Sandworm v0.1.1 - Project file concatenator
+Project file concatenator
 
-Usage: sandworm [command] [options] [directory]
+Usage:
+  sandworm [directory] [flags]
+  sandworm [command]
 
-Commands:
-    generate    Generate concatenated file only
-    push        Generate and push to Claude (default)
-    purge       Remove all files from Claude project
-    setup       Configure Claude project
+Available Commands:
+  completion  Generate the autocompletion script for the specified shell
+  generate    Generate concatenated file only
+  help        Help about any command
+  purge       Remove all files from Claude project
+  push        Generate and push to Claude
+  setup       Configure Claude project
 
-Options:
-  -ignore string
-        Ignore file (default: .gitignore)
-  -k    Keep the generated file (short flag)
-  -keep
-        Keep the generated file after pushing (only affects push)
-  -o string
-        Output file (short flag)
-  -output string
-        Output file (defaults to temp file on push and sandworm.txt for generate)
-  -v    Show version (short flag)
-  -version
-        Show version
+Flags:
+  -h, --help            help for sandworm
+      --ignore string   Ignore file (default: .gitignore)
+  -k, --keep            Keep the generated file after pushing
+  -o, --output string   Output file
+  -v, --version         version for sandworm
+
+Use "sandworm [command] --help" for more information about a command.
 ```
 
 ### Examples
@@ -111,6 +112,17 @@ Generate only, don't push to Claude Project:
 sandworm generate
 ```
 
+### Configuration
+
+Sandworm maintains configuration in two places:
+
+- A global configuration file at `~/.config/sandworm/config.json`
+- A local configuration file at the root of your project, `.sandworm`
+
+The first is used for global configuration, like your Claude session key. The
+latter is project-specific, and stores your Claude organization ID, project ID,
+and the document ID for the file that holds your condensed project.
+
 ### Output Format
 
 The generated file will have the structure:
@@ -144,9 +156,15 @@ FILE: components/Card.tsx
 
 ## Development
 
+We recommend installing both [mise](https://mise.jdx.dev/) (or an equivalent
+version manager) and [just](https://github.com/casey/just) for a smooth
+development experience. The linting command also requires
+[golangci-lint](https://golangci-lint.run/) to be installed, although that one
+runs as part of our CI on Github.
+
 ```bash
 # Setup tooling
-asdf install (or something else that supports .tool-versions)
+mise install (or something else that supports .tool-versions)
 
 # Run project from sources
 just run --help
@@ -157,14 +175,14 @@ just build && bin/sandworm
 # Run all checks
 just lint
 
-# Run tests
+# Run the test suite
 just test
 
 # Other tasks
 just --list
 ```
 
-## Cutting a new release
+### Cutting a new release
 
 New releases are produced with [goreleaser](.goreleaser.yml).
 To create a new release, simply push a tag in the format `vX.Y.Z`.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ allows you to quickly iterate on your code with the help of Claude.
 ## Quick start
 
 ```bash
-brew tap umwelt-studio/tap
+brew tap holonoms/tap
 brew install sandworm
 brew sandworm --help
 ```

--- a/cmd/sandworm/main.go
+++ b/cmd/sandworm/main.go
@@ -5,11 +5,11 @@ import (
 	"os"
 	"time"
 
+	"github.com/holonoms/sandworm/internal/claude"
+	"github.com/holonoms/sandworm/internal/config"
+	"github.com/holonoms/sandworm/internal/processor"
+	"github.com/holonoms/sandworm/internal/util"
 	"github.com/spf13/cobra"
-	"github.com/umwelt-studio/sandworm/internal/claude"
-	"github.com/umwelt-studio/sandworm/internal/config"
-	"github.com/umwelt-studio/sandworm/internal/processor"
-	"github.com/umwelt-studio/sandworm/internal/util"
 )
 
 var (
@@ -218,12 +218,12 @@ func newSetupCmd() *cobra.Command {
 }
 
 func setupClaudeClient(force bool) (*claude.Client, error) {
-	conf, err := config.New("")
+	conf, err := config.New(".")
 	if err != nil {
 		return nil, fmt.Errorf("unable to load config: %w", err)
 	}
 
-	client := claude.New(conf.GetSection("claude"))
+	client := claude.New(conf)
 	ok, err := client.Setup(force)
 	if err != nil {
 		return nil, err

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/umwelt-studio/sandworm
+module github.com/holonoms/sandworm
 
 go 1.23.4
 

--- a/internal/claude/claude.go
+++ b/internal/claude/claude.go
@@ -22,10 +22,10 @@ const (
 	baseURL = "https://api.claude.ai"
 
 	// Configuration keys
-	sessionKey     = "claude.session_key"     // Global
-	organizationID = "claude.organization_id" // Project-specific
-	projectID      = "claude.project_id"      // Project-specific
-	documentID     = "claude.document_id"     // Project-specific
+	sessionKey     = "claude.session_key" // Global, used across sandworm projects
+	organizationID = "claude.organization_id"
+	projectID      = "claude.project_id"
+	documentID     = "claude.document_id"
 )
 
 var sessionKeyRegex = regexp.MustCompile(`^sessionKey=([^;]+)`)
@@ -36,7 +36,7 @@ type Client struct {
 	httpClient *http.Client
 }
 
-// New creates a new Claude API client
+// New creates a new Claude API client using the provided configuration
 func New(conf *config.Config) *Client {
 	return &Client{
 		config: conf,
@@ -54,6 +54,8 @@ func New(conf *config.Config) *Client {
 		},
 	}
 }
+
+// MARK: Interface
 
 // Setup initializes the client configuration, prompting for required values
 // if they're not already set. It validates organization access and project

--- a/internal/claude/claude.go
+++ b/internal/claude/claude.go
@@ -15,36 +15,34 @@ import (
 	"strings"
 	"time"
 
-	"github.com/umwelt-studio/sandworm/internal/config"
+	"github.com/holonoms/sandworm/internal/config"
 )
 
 const (
-	baseURL        = "https://api.claude.ai"
-	sessionKey     = "session_key"
-	documentID     = "document_id"
-	organizationID = "organization_id"
-	projectID      = "project_id"
+	baseURL = "https://api.claude.ai"
+
+	// Configuration keys
+	sessionKey     = "claude.session_key"     // Global
+	organizationID = "claude.organization_id" // Project-specific
+	projectID      = "claude.project_id"      // Project-specific
+	documentID     = "claude.document_id"     // Project-specific
 )
 
-// Client manages interactions with the Claude API, handling authentication,
-// project management, and document operations.
+var sessionKeyRegex = regexp.MustCompile(`^sessionKey=([^;]+)`)
+
+// Client manages interactions with the Claude API
 type Client struct {
-	config     *config.Section
+	config     *config.Config
 	httpClient *http.Client
 }
 
-// Required configuration keys for the client to function
-var requiredKeys = []string{sessionKey, organizationID, projectID}
-var sessionKeyRegex = regexp.MustCompile(`^sessionKey=([^;]+)`)
-
-// New creates a new Claude API client using the provided configuration section.
-func New(cfg *config.Section) *Client {
+// New creates a new Claude API client
+func New(conf *config.Config) *Client {
 	return &Client{
-		config: cfg,
+		config: conf,
 		httpClient: &http.Client{
 			Transport: &http.Transport{
 				TLSClientConfig: &tls.Config{
-					// Minimum TLS version required by Claude; 403's without this.
 					MinVersion: tls.VersionTLS12,
 				},
 				Dial: (&net.Dialer{
@@ -56,8 +54,6 @@ func New(cfg *config.Section) *Client {
 		},
 	}
 }
-
-// MARK: Interface
 
 // Setup initializes the client configuration, prompting for required values
 // if they're not already set. It validates organization access and project
@@ -73,8 +69,7 @@ func (c *Client) Setup(force bool) (bool, error) {
 		if _, err := fmt.Scanln(&key); err != nil {
 			return false, fmt.Errorf("failed to read session key: %w", err)
 		}
-		c.config.Set(sessionKey, key)
-		if err := c.config.Save(); err != nil {
+		if err := c.config.Set(sessionKey, key); err != nil {
 			return false, err
 		}
 	}
@@ -91,17 +86,9 @@ func (c *Client) Setup(force bool) (bool, error) {
 			return false, nil
 		}
 
-		var org organization
-		if len(orgs) == 1 {
-			org = orgs[0]
-			fmt.Printf("\nUsing organization: %s\n", org.Name)
-		} else {
-			fmt.Println("\nSelect an organization:")
-			org = selectFromList(orgs)
-		}
-
-		c.config.Set(organizationID, org.ID)
-		if err := c.config.Save(); err != nil {
+		fmt.Println("\nSelect an organization for this project:")
+		org := selectFromList(orgs)
+		if err := c.config.Set(organizationID, org.ID); err != nil {
 			return false, err
 		}
 	}
@@ -127,8 +114,7 @@ func (c *Client) Setup(force bool) (bool, error) {
 
 		fmt.Println("\nSelect a project:")
 		project := selectFromList(activeProjects)
-		c.config.Set(projectID, project.ID)
-		if err := c.config.Save(); err != nil {
+		if err := c.config.Set(projectID, project.ID); err != nil {
 			return false, err
 		}
 	}
@@ -151,8 +137,7 @@ func (c *Client) Push(filePath, fileName string) error {
 		}
 		for _, doc := range docs {
 			if doc.FileName == fileName {
-				c.config.Set(documentID, doc.ID)
-				if err := c.config.Save(); err != nil {
+				if err := c.config.Set(documentID, doc.ID); err != nil {
 					return err
 				}
 				break
@@ -168,8 +153,7 @@ func (c *Client) Push(filePath, fileName string) error {
 				return err
 			}
 		}
-		c.config.Delete(documentID)
-		if err := c.config.Save(); err != nil {
+		if err := c.config.Delete(documentID); err != nil {
 			return err
 		}
 	}
@@ -185,8 +169,7 @@ func (c *Client) Push(filePath, fileName string) error {
 		return err
 	}
 
-	c.config.Set(documentID, doc.ID)
-	return c.config.Save()
+	return c.config.Set(documentID, doc.ID)
 }
 
 // PurgeProjectFiles removes all files from the current project.
@@ -213,20 +196,20 @@ func (c *Client) PurgeProjectFiles(progressFn func(fileName string, current, tot
 		}
 	}
 
-	c.config.Delete(documentID)
-	if err := c.config.Save(); err != nil {
+	if err := c.config.Delete(documentID); err != nil {
 		return len(docs), err
 	}
 
 	return len(docs), nil
 }
 
-// MARK: Internal helper function
+// MARK: Internal helper functions
 
 // validateConfig ensures all required configuration values are present
 func (c *Client) validateConfig() error {
+	required := []string{sessionKey, organizationID, projectID}
 	var missing []string
-	for _, key := range requiredKeys {
+	for _, key := range required {
 		if !c.config.Has(key) {
 			missing = append(missing, key)
 		}
@@ -272,12 +255,6 @@ func (c *Client) makeRequest(method, path string, body interface{}) ([]byte, err
 		req.Header.Set(k, v)
 	}
 
-	// Debug outgoing HTTP requests as they hit the wire.
-	// dump, err := httputil.DumpRequestOut(req, true)
-	// if err == nil {
-	// 	fmt.Println(string(dump))
-	// }
-
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("request failed: %w", err)
@@ -316,8 +293,9 @@ func (c *Client) makeRequest(method, path string, body interface{}) ([]byte, err
 		if matches := sessionKeyRegex.FindStringSubmatch(cookie); matches != nil {
 			newKey := matches[1]
 			if newKey != c.config.Get(sessionKey) {
-				c.config.Set(sessionKey, newKey)
-				_ = c.config.Save()
+				if err := c.config.Set(sessionKey, newKey); err != nil {
+					return nil, err
+				}
 			}
 		}
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,8 +21,8 @@ type Config struct {
 	project     map[string]map[string]string
 }
 
-// Specify the keys that are shared across projects. These are stored in the global
-// configuration file and are accessible to all sandworm projects.
+// Specify shared keys. These are stored in the global configuration file and are accessible
+// to all sandworm projects.
 var globalKeys = map[string]bool{
 	"claude.session_key": true,
 }
@@ -118,7 +118,7 @@ func (c *Config) Delete(key string) error {
 	return c.saveProject()
 }
 
-// Internal helper functions
+// MARK: Internal helper functions
 
 func splitKey(key string) (section, subKey string) {
 	parts := strings.SplitN(key, ".", 2)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,133 +8,194 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 )
 
-// Config manages persistent settings in a JSON configuration file. It provides
-// section-based organization of settings where each section is a top-level key
-// in a JSON object. This allows logical grouping of related settings while
-// maintaining a simple, flat storage structure.
+// Config manages application configuration, automatically storing values in either
+// global or project-specific locations based on the key.
 type Config struct {
-	path string
-	data map[string]map[string]string
+	globalPath  string
+	projectPath string
+	global      map[string]map[string]string
+	project     map[string]map[string]string
 }
 
-// Section provides access to a specific configuration section. Each section
-// is a collection of key-value pairs under a common namespace (the section name).
-// This allows for organizing related settings together and avoiding key collisions.
-type Section struct {
-	config *Config
-	key    string
+// Specify the keys that are shared across projects. These are stored in the global
+// configuration file and are accessible to all sandworm projects.
+var globalKeys = map[string]bool{
+	"claude.session_key": true,
 }
 
-// New creates a new Config instance. If no path is provided (empty string),
-// it defaults to ".sandworm" in the current directory. The function will
-// attempt to load existing configuration from the specified path but won't
-// fail if the file doesn't exist - this allows for gradual configuration
-// building where settings are added as needed.
-//
-// The function will return an error only if the configuration file exists
-// but cannot be read or contains invalid JSON.
-func New(path string) (*Config, error) {
-	if path == "" {
-		path = ".sandworm"
+// New creates a new Config instance. If projectPath is empty, only global config
+// is used. Global config is stored in ~/.config/sandworm/config.json, while
+// project config is stored in .sandworm in the project directory.
+func New(projectPath string) (*Config, error) {
+	globalPath, err := getGlobalConfigPath()
+	if err != nil {
+		return nil, fmt.Errorf("failed to determine global config path: %w", err)
 	}
 
 	config := &Config{
-		path: path,
-		data: make(map[string]map[string]string),
+		globalPath:  filepath.Join(globalPath, "config.json"),
+		projectPath: filepath.Join(projectPath, ".sandworm"),
+		global:      make(map[string]map[string]string),
+		project:     make(map[string]map[string]string),
 	}
 
-	if err := config.load(); err != nil {
-		// We don't treat a missing configuration file as an error because
-		// it's a normal scenario when first running the application or when
-		// a user wants to start with a fresh configuration. The file will
-		// be created when the first settings are saved.
-		if !os.IsNotExist(err) {
-			return nil, fmt.Errorf("failed to load config: %w", err)
+	// Load global config
+	if err := config.loadGlobal(); err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("failed to load global config: %w", err)
+	}
+
+	// Load project config if path provided
+	if projectPath != "" {
+		if err := config.loadProject(); err != nil && !os.IsNotExist(err) {
+			return nil, fmt.Errorf("failed to load project config: %w", err)
 		}
 	}
 
 	return config, nil
 }
 
-// GetSection returns a configuration section for the specified key. If the
-// section doesn't exist, it's created automatically. This allows for
-// adding new sections on demand without explicit initialization.
-//
-// Example:
-//
-//	config, _ := config.New("")
-//	claudeSection := config.GetSection("claude")
-//	claudeSection.Set("api_key", "abc123")
-func (c *Config) GetSection(key string) *Section {
-	if _, exists := c.data[key]; !exists {
-		c.data[key] = make(map[string]string)
+// Has checks if a configuration key exists
+func (c *Config) Has(key string) bool {
+	section, subKey := splitKey(key)
+	if globalKeys[key] {
+		sectionData, exists := c.global[section]
+		if !exists {
+			return false
+		}
+		_, exists = sectionData[subKey]
+		return exists
 	}
-	return &Section{config: c, key: key}
+	sectionData, exists := c.project[section]
+	if !exists {
+		return false
+	}
+	_, exists = sectionData[subKey]
+	return exists
 }
 
-// load reads and parses the configuration file. It's called automatically
-// by New() but can also be used to reload configuration from disk if needed.
-// The function expects the file to contain a valid JSON object where each
-// top-level key represents a section containing key-value pairs.
-func (c *Config) load() error {
-	data, err := os.ReadFile(c.path)
+// Get retrieves a configuration value. Returns empty string if not found.
+func (c *Config) Get(key string) string {
+	section, subKey := splitKey(key)
+	if globalKeys[key] {
+		return c.global[section][subKey]
+	}
+	return c.project[section][subKey]
+}
+
+// Set stores a configuration value and persists it to the appropriate location
+func (c *Config) Set(key, value string) error {
+	section, subKey := splitKey(key)
+	if globalKeys[key] {
+		if _, exists := c.global[section]; !exists {
+			c.global[section] = make(map[string]string)
+		}
+		c.global[section][subKey] = value
+		return c.saveGlobal()
+	}
+	if _, exists := c.project[section]; !exists {
+		c.project[section] = make(map[string]string)
+	}
+	c.project[section][subKey] = value
+	return c.saveProject()
+}
+
+// Delete removes a configuration value
+func (c *Config) Delete(key string) error {
+	section, subKey := splitKey(key)
+	if globalKeys[key] {
+		if sectionData, exists := c.global[section]; exists {
+			delete(sectionData, subKey)
+		}
+		return c.saveGlobal()
+	}
+	if sectionData, exists := c.project[section]; exists {
+		delete(sectionData, subKey)
+	}
+	return c.saveProject()
+}
+
+// Internal helper functions
+
+func splitKey(key string) (section, subKey string) {
+	parts := strings.SplitN(key, ".", 2)
+	if len(parts) != 2 {
+		return "", key
+	}
+	return parts[0], parts[1]
+}
+
+func (c *Config) loadGlobal() error {
+	return c.load(c.globalPath, &c.global)
+}
+
+func (c *Config) loadProject() error {
+	return c.load(c.projectPath, &c.project)
+}
+
+func (c *Config) load(path string, data *map[string]map[string]string) error {
+	content, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}
-
-	return json.Unmarshal(data, &c.data)
+	return json.Unmarshal(content, data)
 }
 
-// Save writes the current configuration state to disk in JSON format.
-// It ensures the target directory exists and creates it if necessary.
-// The resulting file uses standard file permissions (0644) to ensure
-// it's readable by the user and group but protected from other users.
-func (c *Config) Save() error {
-	data, err := json.MarshalIndent(c.data, "", "  ")
+func (c *Config) saveGlobal() error {
+	return c.save(c.globalPath, c.global)
+}
+
+func (c *Config) saveProject() error {
+	return c.save(c.projectPath, c.project)
+}
+
+func (c *Config) save(path string, data map[string]map[string]string) error {
+	content, err := json.MarshalIndent(data, "", "  ")
 	if err != nil {
 		return fmt.Errorf("failed to marshal config: %w", err)
 	}
 
-	// Ensure the parent directory exists before attempting to write
-	// This handles cases where the config file is in a subdirectory
-	dir := filepath.Dir(c.path)
+	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("failed to create config directory: %w", err)
 	}
 
-	if err := os.WriteFile(c.path, data, 0o644); err != nil {
+	if err := os.WriteFile(path, content, 0o644); err != nil {
 		return fmt.Errorf("failed to write config: %w", err)
 	}
 
 	return nil
 }
 
-// Has checks if a key exists in the section, returning true if it does.
-func (s *Section) Has(key string) bool {
-	_, exists := s.config.data[s.key][key]
-	return exists
-}
+func getGlobalConfigPath() (string, error) {
+	var configDir string
 
-// Get retrieves a value from the section. If the key doesn't exist,
-// it returns an empty string.
-func (s *Section) Get(key string) string {
-	return s.config.data[s.key][key]
-}
+	switch runtime.GOOS {
+	case "darwin", "linux", "freebsd", "openbsd", "netbsd":
+		// Check XDG_CONFIG_HOME first
+		if xdgHome := os.Getenv("XDG_CONFIG_HOME"); xdgHome != "" {
+			configDir = xdgHome
+		} else {
+			// Fall back to ~/.config
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return "", fmt.Errorf("failed to get home directory: %w", err)
+			}
+			configDir = filepath.Join(home, ".config")
+		}
 
-// Set stores a value in the section. The change is only held in memory
-// until Save() is called to persist it to disk.
-func (s *Section) Set(key, value string) {
-	s.config.data[s.key][key] = value
-}
+	case "windows":
+		configDir = os.Getenv("APPDATA")
+		if configDir == "" {
+			return "", fmt.Errorf("APPDATA environment variable not set")
+		}
 
-func (s *Section) Delete(key string) {
-	delete(s.config.data[s.key], key)
-}
+	default:
+		return "", fmt.Errorf("unsupported operating system: %s", runtime.GOOS)
+	}
 
-// Save persists the current configuration to disk. This is a convenience
-// method that calls Save() on the underlying Config instance.
-func (s *Section) Save() error {
-	return s.config.Save()
+	return filepath.Join(configDir, "sandworm"), nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -129,19 +129,19 @@ func splitKey(key string) (section, subKey string) {
 }
 
 func (c *Config) loadGlobal() error {
-	return c.load(c.globalPath, &c.global)
+	return c.load(c.globalPath, c.global)
 }
 
 func (c *Config) loadProject() error {
-	return c.load(c.projectPath, &c.project)
+	return c.load(c.projectPath, c.project)
 }
 
-func (c *Config) load(path string, data *map[string]map[string]string) error {
+func (c *Config) load(path string, data map[string]map[string]string) error {
 	content, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}
-	return json.Unmarshal(content, data)
+	return json.Unmarshal(content, &data)
 }
 
 func (c *Config) saveGlobal() error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -15,7 +15,7 @@ func TestConfig(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	configPath := filepath.Join(tmpDir, "config.json")
+	configPath := filepath.Join(tmpDir, "test-project")
 
 	t.Run("new config file", func(t *testing.T) {
 		cfg, err := New(configPath)
@@ -23,26 +23,42 @@ func TestConfig(t *testing.T) {
 			t.Fatalf("Failed to create config: %v", err)
 		}
 
-		section := cfg.GetSection("test")
-		section.Set("key", "value")
-
-		if err := section.Save(); err != nil {
-			t.Fatalf("Failed to save config: %v", err)
+		// Set some values
+		if err := cfg.Set("claude.session_key", "global-value"); err != nil {
+			t.Fatalf("Failed to set global value: %v", err)
+		}
+		if err := cfg.Set("claude.project_id", "project-value"); err != nil {
+			t.Fatalf("Failed to set project value: %v", err)
 		}
 
-		// Verify file contents
-		data, err := os.ReadFile(configPath)
+		// Check global config file
+		globalData, err := os.ReadFile(cfg.globalPath)
 		if err != nil {
-			t.Fatalf("Failed to read config file: %v", err)
+			t.Fatalf("Failed to read global config file: %v", err)
 		}
 
-		var config map[string]map[string]string
-		if err := json.Unmarshal(data, &config); err != nil {
-			t.Fatalf("Failed to parse config file: %v", err)
+		var globalConfig map[string]map[string]string
+		if err := json.Unmarshal(globalData, &globalConfig); err != nil {
+			t.Fatalf("Failed to parse global config file: %v", err)
 		}
 
-		if config["test"]["key"] != "value" {
-			t.Errorf("Expected value 'value', got '%s'", config["test"]["key"])
+		if globalConfig["claude"]["session_key"] != "global-value" {
+			t.Errorf("Expected global value 'global-value', got '%s'", globalConfig["claude"]["session_key"])
+		}
+
+		// Check project config file
+		projectData, err := os.ReadFile(cfg.projectPath)
+		if err != nil {
+			t.Fatalf("Failed to read project config file: %v", err)
+		}
+
+		var projectConfig map[string]map[string]string
+		if err := json.Unmarshal(projectData, &projectConfig); err != nil {
+			t.Fatalf("Failed to parse project config file: %v", err)
+		}
+
+		if projectConfig["claude"]["project_id"] != "project-value" {
+			t.Errorf("Expected project value 'project-value', got '%s'", projectConfig["claude"]["project_id"])
 		}
 	})
 
@@ -52,19 +68,94 @@ func TestConfig(t *testing.T) {
 			t.Fatalf("Failed to load config: %v", err)
 		}
 
-		section := cfg.GetSection("test")
-		if got := section.Get("key"); got != "value" {
-			t.Errorf("Expected value 'value', got '%s'", got)
+		// Check values persist
+		if !cfg.Has("claude.session_key") {
+			t.Error("Expected to find global key")
+		}
+		if got := cfg.Get("claude.session_key"); got != "global-value" {
+			t.Errorf("Expected global value 'global-value', got '%s'", got)
+		}
+
+		if !cfg.Has("claude.project_id") {
+			t.Error("Expected to find project key")
+		}
+		if got := cfg.Get("claude.project_id"); got != "project-value" {
+			t.Errorf("Expected project value 'project-value', got '%s'", got)
+		}
+	})
+
+	t.Run("delete values", func(t *testing.T) {
+		cfg, err := New(configPath)
+		if err != nil {
+			t.Fatalf("Failed to load config: %v", err)
+		}
+
+		// Delete values
+		if err := cfg.Delete("claude.session_key"); err != nil {
+			t.Fatalf("Failed to delete global value: %v", err)
+		}
+		if err := cfg.Delete("claude.project_id"); err != nil {
+			t.Fatalf("Failed to delete project value: %v", err)
+		}
+
+		// Check values are gone
+		if cfg.Has("claude.session_key") {
+			t.Error("Global key should be deleted")
+		}
+		if cfg.Has("claude.project_id") {
+			t.Error("Project key should be deleted")
 		}
 	})
 
 	t.Run("invalid JSON", func(t *testing.T) {
-		if err := os.WriteFile(configPath, []byte("invalid json"), 0o644); err != nil {
+		badConfigPath := filepath.Join(tmpDir, "bad-config")
+		// Create the directory first
+		if err := os.MkdirAll(badConfigPath, 0o755); err != nil {
+			t.Fatalf("Failed to create directory: %v", err)
+		}
+		if err := os.WriteFile(
+			filepath.Join(badConfigPath, ".sandworm"),
+			[]byte("invalid json"),
+			0o644,
+		); err != nil {
 			t.Fatalf("Failed to write invalid config: %v", err)
 		}
 
-		if _, err := New(configPath); err == nil {
+		if _, err := New(badConfigPath); err == nil {
 			t.Error("Expected error for invalid JSON, got nil")
+		}
+	})
+
+	t.Run("missing directory", func(t *testing.T) {
+		cfg, err := New(filepath.Join(tmpDir, "nonexistent"))
+		if err != nil {
+			t.Fatalf("Failed to create config with nonexistent directory: %v", err)
+		}
+
+		// Should be able to set and get values
+		if err := cfg.Set("claude.test_key", "test_value"); err != nil {
+			t.Fatalf("Failed to set value: %v", err)
+		}
+
+		if got := cfg.Get("claude.test_key"); got != "test_value" {
+			t.Errorf("Expected value 'test_value', got '%s'", got)
+		}
+	})
+
+	t.Run("empty values", func(t *testing.T) {
+		cfg, err := New(configPath)
+		if err != nil {
+			t.Fatalf("Failed to create config: %v", err)
+		}
+
+		// Get nonexistent value
+		if got := cfg.Get("nonexistent.key"); got != "" {
+			t.Errorf("Expected empty string for nonexistent key, got '%s'", got)
+		}
+
+		// Check nonexistent value
+		if cfg.Has("nonexistent.key") {
+			t.Error("Has() should return false for nonexistent key")
 		}
 	})
 }

--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 
 	"github.com/go-git/go-git/v5/plumbing/format/gitignore"
-	"github.com/umwelt-studio/sandworm/internal/filetree"
+	"github.com/holonoms/sandworm/internal/filetree"
 )
 
 const separator = "================================================================================"


### PR DESCRIPTION
Sandworm now uses `$XDG_CONFIG_HOME` when storing global configuration keys. At the moment this is only one key (the user's Anthropic session key), but this may expand to include default ignores, default includes, etc.