### PR TITLE
Optionally add line numbers to output

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -29,10 +29,20 @@ func NewRootCmd() *cobra.Command {
 		RunE: newPushCmd(opts).RunE,
 	}
 
-	// Add global flags
 	rootCmd.PersistentFlags().StringVarP(&opts.OutputFile, "output", "o", "", "Output file")
-	rootCmd.PersistentFlags().StringVar(&opts.IgnoreFile, "ignore", "", "Ignore file (default: .gitignore)")
+	rootCmd.PersistentFlags().StringVarP(&opts.IgnoreFile, "ignore", "i", "", "Ignore file (default: .gitignore)")
 	rootCmd.PersistentFlags().BoolVarP(&opts.KeepFile, "keep", "k", false, "Keep the generated file after pushing")
+
+	var showLineNumbers bool
+	rootCmd.PersistentFlags().BoolVarP(&showLineNumbers, "line-numbers", "n", false, "Show line numbers in output (overrides config setting)")
+	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, _ []string) error {
+		// Set the pointer only if the flag was explicitly provided; otherwise
+		// leave it as nil to use the project settings.
+		if cmd.Flags().Changed("line-numbers") {
+			opts.ShowLineNumbers = &showLineNumbers
+		}
+		return nil
+	}
 
 	// Add commands
 	rootCmd.AddCommand(

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -26,7 +26,7 @@ func NewRootCmd() *cobra.Command {
 		// where folder would otherwise be interpreted as a subcommand and fail.
 		Args: cobra.ArbitraryArgs,
 		// When no subcommand is supplied, execute the push command
-		RunE: NewPushCmd(opts).RunE,
+		RunE: newPushCmd(opts).RunE,
 	}
 
 	// Add global flags
@@ -36,10 +36,11 @@ func NewRootCmd() *cobra.Command {
 
 	// Add commands
 	rootCmd.AddCommand(
-		NewGenerateCmd(opts),
-		NewPushCmd(opts),
-		NewPurgeCmd(),
-		NewSetupCmd(),
+		newGenerateCmd(opts),
+		newPushCmd(opts),
+		newPurgeCmd(),
+		newSetupCmd(),
+		newConfigCmd(),
 	)
 
 	return rootCmd

--- a/internal/cli/cmd_config.go
+++ b/internal/cli/cmd_config.go
@@ -1,0 +1,264 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/holonoms/sandworm/internal/config"
+	"github.com/spf13/cobra"
+)
+
+// ConfigOption represents a configuration option
+type ConfigOption struct {
+	Key         string
+	Description string
+	Default     string
+	ValidValues []string // For enumerated values like true/false
+	Validator   func(string) error
+}
+
+// Registry of all available configuration options
+var configOptions = []ConfigOption{
+	{
+		Key:         "claude.organization_id",
+		Description: "The organization ID to use for the Claude API",
+		Default:     "",
+	},
+	{
+		Key:         "claude.project_id",
+		Description: "The project ID to use for the Claude API",
+		Default:     "",
+	},
+	{
+		Key:         "claude.document_id",
+		Description: "The document ID to use for the Claude API",
+		Default:     "",
+	},
+}
+
+// MARK: Sub-commands
+
+// newConfigCmd creates the config command and its subcommands
+func newConfigCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "config",
+		Short: "Manage project configuration",
+	}
+
+	// Add subcommands
+	cmd.AddCommand(
+		newConfigListCmd(),
+		newConfigGetCmd(),
+		newConfigSetCmd(),
+		newConfigUnsetCmd(),
+	)
+
+	return cmd
+}
+
+func newConfigListCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List all configuration values",
+		Args:  cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return runConfigList()
+		},
+	}
+
+	return cmd
+}
+
+func runConfigList() error {
+	cfg, err := config.New(".")
+	if err != nil {
+		return fmt.Errorf("unable to load config: %w", err)
+	}
+
+	fmt.Println("Available configuration options:")
+	fmt.Println()
+
+	for _, option := range configOptions {
+		fmt.Printf("  %s\n", option.Key)
+		fmt.Printf("    Description: %s\n", option.Description)
+		fmt.Printf("    Default: %s\n", option.Default)
+
+		if cfg.Has(option.Key) {
+			value := cfg.Get(option.Key)
+			fmt.Printf("    Current: %s\n", value)
+		} else {
+			fmt.Printf("    Current: %s (default)\n", option.Default)
+		}
+		fmt.Println()
+	}
+
+	return nil
+}
+
+func newConfigSetCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "set <key> <value>",
+		Short: "Set a configuration value",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(_ *cobra.Command, args []string) error {
+			return runConfigSet(args[0], args[1])
+		},
+		ValidArgsFunction: func(
+			cmd *cobra.Command,
+			args []string,
+			toComplete string,
+		) ([]string, cobra.ShellCompDirective) {
+			if len(args) == 0 {
+				return configOptionsKeys(), cobra.ShellCompDirectiveNoFileComp
+			}
+			// For values, provide common completions based on the key
+			if len(args) == 1 {
+				option := findConfigOption(args[0])
+				if option != nil && len(option.ValidValues) > 0 {
+					return option.ValidValues, cobra.ShellCompDirectiveNoFileComp
+				}
+			}
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		},
+	}
+
+	return cmd
+}
+
+func runConfigSet(key, value string) error {
+	// Find the configuration option
+	option := findConfigOption(key)
+	if option == nil {
+		return fmt.Errorf("unknown configuration option: %s\n\nRun 'sandworm config list' to see available options", key)
+	}
+
+	// Validate the value
+	if option.Validator != nil {
+		if err := option.Validator(value); err != nil {
+			return fmt.Errorf("invalid value for %s: %w", key, err)
+		}
+	}
+
+	cfg, err := config.New(".")
+	if err != nil {
+		return fmt.Errorf("unable to load config: %w", err)
+	}
+
+	if err := cfg.Set(key, value); err != nil {
+		return fmt.Errorf("unable to set config: %w", err)
+	}
+
+	fmt.Printf("Set %s = %s\n", key, value)
+	return nil
+}
+
+func newConfigGetCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get <key>",
+		Short: "Get a configuration value",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			return runConfigGet(args[0])
+		},
+		ValidArgsFunction: func(
+			cmd *cobra.Command,
+			args []string,
+			toComplete string,
+		) ([]string, cobra.ShellCompDirective) {
+			if len(args) == 0 {
+				return configOptionsKeys(), cobra.ShellCompDirectiveNoFileComp
+			}
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		},
+	}
+
+	return cmd
+}
+
+func runConfigGet(key string) error {
+	// Validate that the key is a known option
+	option := findConfigOption(key)
+	if option == nil {
+		return fmt.Errorf("unknown configuration option: %s\n\nRun 'sandworm config list' to see available options", key)
+	}
+
+	cfg, err := config.New(".")
+	if err != nil {
+		return fmt.Errorf("unable to load config: %w", err)
+	}
+
+	if !cfg.Has(key) {
+		fmt.Printf("%s = %s (default)\n", key, option.Default)
+		return nil
+	}
+
+	value := cfg.Get(key)
+	fmt.Printf("%s = %s\n", key, value)
+	return nil
+}
+
+func newConfigUnsetCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "unset <key>",
+		Short: "Unset a configuration value",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			return runConfigUnset(args[0])
+		},
+		ValidArgsFunction: func(
+			cmd *cobra.Command,
+			args []string,
+			toComplete string,
+		) ([]string, cobra.ShellCompDirective) {
+			if len(args) == 0 {
+				return configOptionsKeys(), cobra.ShellCompDirectiveNoFileComp
+			}
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		},
+	}
+
+	return cmd
+}
+
+func runConfigUnset(key string) error {
+	cfg, err := config.New(".")
+	if err != nil {
+		return fmt.Errorf("unable to load config: %w", err)
+	}
+
+	if err := cfg.Delete(key); err != nil {
+		return fmt.Errorf("unable to unset config: %w", err)
+	}
+
+	fmt.Printf("Unset %s\n", key)
+	return nil
+}
+
+// MARK: Helpers
+
+// findConfigOption finds a config option by key
+func findConfigOption(key string) *ConfigOption {
+	for i := range configOptions {
+		if configOptions[i].Key == key {
+			return &configOptions[i]
+		}
+	}
+	return nil
+}
+
+func configOptionsKeys() []string {
+	var keys []string
+	for _, option := range configOptions {
+		keys = append(keys, option.Key)
+	}
+	return keys
+}
+
+// MARK: Validators
+
+// validateBoolOption validates that a value is either "true" or "false"
+func validateBoolOption(value string) error {
+	if value != "true" && value != "false" {
+		return fmt.Errorf("value must be either 'true' or 'false', got: %s", value)
+	}
+	return nil
+}

--- a/internal/cli/cmd_config.go
+++ b/internal/cli/cmd_config.go
@@ -33,6 +33,13 @@ var configOptions = []ConfigOption{
 		Description: "The document ID to use for the Claude API",
 		Default:     "",
 	},
+	{
+		Key:         "processor.print_line_numbers",
+		Description: "Print line numbers in the output",
+		Default:     "false",
+		ValidValues: []string{"true", "false"},
+		Validator:   validateBoolOption,
+	},
 }
 
 // MARK: Sub-commands
@@ -103,9 +110,9 @@ func newConfigSetCmd() *cobra.Command {
 			return runConfigSet(args[0], args[1])
 		},
 		ValidArgsFunction: func(
-			cmd *cobra.Command,
+			_ *cobra.Command,
 			args []string,
-			toComplete string,
+			_ string,
 		) ([]string, cobra.ShellCompDirective) {
 			if len(args) == 0 {
 				return configOptionsKeys(), cobra.ShellCompDirectiveNoFileComp
@@ -160,9 +167,9 @@ func newConfigGetCmd() *cobra.Command {
 			return runConfigGet(args[0])
 		},
 		ValidArgsFunction: func(
-			cmd *cobra.Command,
+			_ *cobra.Command,
 			args []string,
-			toComplete string,
+			_ string,
 		) ([]string, cobra.ShellCompDirective) {
 			if len(args) == 0 {
 				return configOptionsKeys(), cobra.ShellCompDirectiveNoFileComp
@@ -205,9 +212,9 @@ func newConfigUnsetCmd() *cobra.Command {
 			return runConfigUnset(args[0])
 		},
 		ValidArgsFunction: func(
-			cmd *cobra.Command,
+			_ *cobra.Command,
 			args []string,
-			toComplete string,
+			_ string,
 		) ([]string, cobra.ShellCompDirective) {
 			if len(args) == 0 {
 				return configOptionsKeys(), cobra.ShellCompDirectiveNoFileComp
@@ -246,9 +253,9 @@ func findConfigOption(key string) *ConfigOption {
 }
 
 func configOptionsKeys() []string {
-	var keys []string
-	for _, option := range configOptions {
-		keys = append(keys, option.Key)
+	keys := make([]string, len(configOptions))
+	for i, option := range configOptions {
+		keys[i] = option.Key
 	}
 	return keys
 }

--- a/internal/cli/cmd_generate.go
+++ b/internal/cli/cmd_generate.go
@@ -8,8 +8,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// NewGenerateCmd creates the generate command
-func NewGenerateCmd(opts *Options) *cobra.Command {
+// newGenerateCmd creates the generate command
+func newGenerateCmd(opts *Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "generate [directory]",
 		Short: "Generate concatenated file only",

--- a/internal/cli/cmd_generate.go
+++ b/internal/cli/cmd_generate.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 
+	"github.com/holonoms/sandworm/internal/config"
 	"github.com/holonoms/sandworm/internal/processor"
 	"github.com/holonoms/sandworm/internal/util"
 	"github.com/spf13/cobra"
@@ -38,7 +39,25 @@ func runGenerate(opts *Options) (int64, error) {
 		opts.Directory = "."
 	}
 
-	p, err := processor.New(opts.Directory, opts.OutputFile, opts.IgnoreFile)
+	printLineNumbers := false
+	if opts.ShowLineNumbers != nil {
+		printLineNumbers = *opts.ShowLineNumbers
+	} else {
+		// If line-numbers flag wasn't explicitly set, load & check the project's settings.
+		cfg, err := config.New(opts.Directory)
+		if err != nil {
+			return 0, fmt.Errorf("unable to load config: %w", err)
+		}
+
+		if cfg.Has("processor.print_line_numbers") {
+			value := cfg.Get("processor.print_line_numbers")
+			if value == "true" {
+				printLineNumbers = true
+			}
+		}
+	}
+
+	p, err := processor.New(opts.Directory, opts.OutputFile, opts.IgnoreFile, printLineNumbers)
 	if err != nil {
 		return 0, fmt.Errorf("unable to create processor: %w", err)
 	}

--- a/internal/cli/cmd_purge.go
+++ b/internal/cli/cmd_purge.go
@@ -6,8 +6,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// NewPurgeCmd creates the purge command
-func NewPurgeCmd() *cobra.Command {
+// newPurgeCmd creates the purge command
+func newPurgeCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "purge",
 		Short: "Remove all files from Claude project",

--- a/internal/cli/cmd_push.go
+++ b/internal/cli/cmd_push.go
@@ -11,8 +11,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// NewPushCmd creates the push command
-func NewPushCmd(opts *Options) *cobra.Command {
+// newPushCmd creates the push command
+func newPushCmd(opts *Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "push [directory]",
 		Short: "Generate and push to Claude",

--- a/internal/cli/cmd_setup.go
+++ b/internal/cli/cmd_setup.go
@@ -6,8 +6,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// NewSetupCmd creates the setup command
-func NewSetupCmd() *cobra.Command {
+// newSetupCmd creates the setup command
+func newSetupCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "setup",
 		Short: "Configure Claude project",

--- a/internal/cli/options.go
+++ b/internal/cli/options.go
@@ -26,6 +26,10 @@ type Options struct {
 	// Directory specifies the root directory to process.
 	// If empty, defaults to the current directory (".").
 	Directory string
+
+	// ShowLineNumbers determines whether to show line numbers in the output.
+	// If nil, the value from config will be used. If set, it overrides the config.
+	ShowLineNumbers *bool
 }
 
 // SetDefaults sets default values for options based on the command context

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -118,6 +118,32 @@ func (c *Config) Delete(key string) error {
 	return c.saveProject()
 }
 
+// GetAllKeys returns all configuration keys as a slice of strings
+func (c *Config) GetAllKeys() []string {
+	var keys []string
+
+	// Add global keys
+	for section, sectionData := range c.global {
+		for subKey := range sectionData {
+			keys = append(keys, section+"."+subKey)
+		}
+	}
+
+	// Add project keys
+	for section, sectionData := range c.project {
+		for subKey := range sectionData {
+			keys = append(keys, section+"."+subKey)
+		}
+	}
+
+	return keys
+}
+
+// IsGlobalKey checks if a key is stored in global config
+func (c *Config) IsGlobalKey(key string) bool {
+	return globalKeys[key]
+}
+
 // MARK: Internal helper functions
 
 func splitKey(key string) (section, subKey string) {


### PR DESCRIPTION
Optionally adds line numbers to each input file in the output file. Useful for tooling that consumes code and generates documentation with links to highlight certain portions (example [highlight](https://github.com/holonoms/sandworm/blob/main/cmd/sandworm/main.go#L11-L13)).

Line number padding is based on total number of lines in the file (none for files with < 10 lines).

Usage:
```sh
sandworm generate -n
sandworm generate --line-numbers
```

Example output:
```
================================================================================
FILE: cmd/sandworm/main.go
================================================================================
 1: // Package main is the main package for the sandworm CLI.
 2: package main
 3: 
 4: import (
 5: 	"os"
 6: 
 7: 	"github.com/holonoms/sandworm/internal/cli"
 8: )
 9: 
10: func main() {
11: 	if err := cli.NewRootCmd().Execute(); err != nil {
12: 		os.Exit(1)
13: 	}
14: }
15: 
```